### PR TITLE
[#3] 검증 성공

### DIFF
--- a/src/main/java/com/baedal/order/adapter/in/message/dto/OrderValidateRequest.java
+++ b/src/main/java/com/baedal/order/adapter/in/message/dto/OrderValidateRequest.java
@@ -1,0 +1,13 @@
+package com.baedal.order.adapter.in.message.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class OrderValidateRequest {
+
+  private String orderTransactionId;
+  private String domain;
+
+}

--- a/src/main/java/com/baedal/order/adapter/in/message/listener/OrderListener.java
+++ b/src/main/java/com/baedal/order/adapter/in/message/listener/OrderListener.java
@@ -21,7 +21,7 @@ public class OrderListener {
 
   @KafkaListener(topics = "order.orderValidate", groupId = "order-validate-group")
   public void orderValidate(ConsumerRecord<String, String> record) {
-    Long orderTransactionId = Long.parseLong(record.key());
+    String orderTransactionId = record.key();
     OrderValidateRequest req = converter.jsonToDto(record.value(), OrderValidateRequest.class);
     OrderValidateCommand.Request command = mapper.orderValidateToCommand(orderTransactionId, req);
     orderUseCase.orderValidate(command);

--- a/src/main/java/com/baedal/order/adapter/in/message/listener/OrderListener.java
+++ b/src/main/java/com/baedal/order/adapter/in/message/listener/OrderListener.java
@@ -19,7 +19,7 @@ public class OrderListener {
   private final OrderUseCase orderUseCase;
 
 
-  @KafkaListener(topics = "order.orderValidationSuccess", groupId = "order-validate-group")
+  @KafkaListener(topics = "order.orderValidate", groupId = "order-validate-group")
   public void orderValidate(ConsumerRecord<String, String> record) {
     Long orderTransactionId = Long.parseLong(record.key());
     OrderValidateRequest req = converter.jsonToDto(record.value(), OrderValidateRequest.class);

--- a/src/main/java/com/baedal/order/adapter/in/message/listener/OrderListener.java
+++ b/src/main/java/com/baedal/order/adapter/in/message/listener/OrderListener.java
@@ -1,0 +1,30 @@
+package com.baedal.order.adapter.in.message.listener;
+
+import com.baedal.order.adapter.in.message.dto.OrderValidateRequest;
+import com.baedal.order.adapter.in.message.mapper.OrderListenerMapper;
+import com.baedal.order.application.command.OrderValidateCommand;
+import com.baedal.order.application.port.in.OrderUseCase;
+import com.baedal.order.util.Converter;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OrderListener {
+
+  private final Converter converter;
+  private final OrderListenerMapper mapper;
+  private final OrderUseCase orderUseCase;
+
+
+  @KafkaListener(topics = "order.orderValidationSuccess", groupId = "order-validate-group")
+  public void orderValidate(ConsumerRecord<String, String> record) {
+    Long orderTransactionId = Long.parseLong(record.key());
+    OrderValidateRequest req = converter.jsonToDto(record.value(), OrderValidateRequest.class);
+    OrderValidateCommand.Request command = mapper.orderValidateToCommand(orderTransactionId, req);
+    orderUseCase.orderValidate(command);
+  }
+
+}

--- a/src/main/java/com/baedal/order/adapter/in/message/mapper/OrderListenerMapper.java
+++ b/src/main/java/com/baedal/order/adapter/in/message/mapper/OrderListenerMapper.java
@@ -1,0 +1,14 @@
+package com.baedal.order.adapter.in.message.mapper;
+
+import com.baedal.order.adapter.in.message.dto.OrderValidateRequest;
+import com.baedal.order.application.command.OrderValidateCommand;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface OrderListenerMapper {
+
+  // 주문 검증
+  OrderValidateCommand.Request orderValidateToCommand(
+      Long orderTransactionId, OrderValidateRequest req
+  );
+}

--- a/src/main/java/com/baedal/order/adapter/in/message/mapper/OrderListenerMapper.java
+++ b/src/main/java/com/baedal/order/adapter/in/message/mapper/OrderListenerMapper.java
@@ -9,6 +9,6 @@ public interface OrderListenerMapper {
 
   // 주문 검증
   OrderValidateCommand.Request orderValidateToCommand(
-      Long orderTransactionId, OrderValidateRequest req
+      String orderTransactionId, OrderValidateRequest req
   );
 }

--- a/src/main/java/com/baedal/order/adapter/out/messaging/MessageSenderAdapter.java
+++ b/src/main/java/com/baedal/order/adapter/out/messaging/MessageSenderAdapter.java
@@ -35,4 +35,9 @@ public class MessageSenderAdapter implements MessageSenderPort {
 
   }
 
+  @Override
+  public void failOrder(String orderTransactionId, String errorMessage) {
+    kafkaSender.sendMessage("payment.failOrder", orderTransactionId, errorMessage);
+  }
+
 }

--- a/src/main/java/com/baedal/order/adapter/out/messaging/MessageSenderAdapter.java
+++ b/src/main/java/com/baedal/order/adapter/out/messaging/MessageSenderAdapter.java
@@ -1,6 +1,5 @@
 package com.baedal.order.adapter.out.messaging;
 
-import com.baedal.order.application.command.AddOrderCommand.PaymentInfo;
 import com.baedal.order.application.port.out.MessageSenderPort;
 import com.baedal.order.domain.model.cart.ValidateCartOrderInfo;
 import com.baedal.order.domain.model.product.ValidateProductOrderInfo;
@@ -29,9 +28,11 @@ public class MessageSenderAdapter implements MessageSenderPort {
   public void validateStoreOrderInfo(ValidateStoreOrderInfo.Request req) {
     kafkaSender.sendMessage("cart.validateStoreOrderInfo", req.getOrderTransactionId(), req);
   }
-//
-//  @Override
-//  public void sendOrderFinalCheck(String orderTransactionId) {
-//    kafkaSender.sendMessage("order.finalCheck", orderTransactionId, orderTransactionId);
-//  }
+
+  @Override
+  public void approvePayment(String orderTransactionId) {
+    kafkaSender.sendMessage("payment.approvePayment", orderTransactionId, null);
+
+  }
+
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/adapters/OrderCacheRepositoryAdapter.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/adapters/OrderCacheRepositoryAdapter.java
@@ -1,7 +1,6 @@
 package com.baedal.order.adapter.out.persistence.adapters;
 
-import com.baedal.order.adapter.out.persistence.dto.AddOrderValidateRequest;
-import com.baedal.order.adapter.out.persistence.dto.GetOrderValidateResponse;
+import com.baedal.order.adapter.out.persistence.dto.OrderValidateDto;
 import com.baedal.order.adapter.out.persistence.manager.OrderCacheCreator;
 import com.baedal.order.adapter.out.persistence.manager.OrderCacheReader;
 import com.baedal.order.adapter.out.persistence.mapper.OrderPersistenceMapper;
@@ -22,13 +21,13 @@ public class OrderCacheRepositoryAdapter implements OrderCacheRepositoryPort {
 
   @Override
   public void addOrderValidate(AddOrderValidate req) {
-    AddOrderValidateRequest dto = orderMapper.addOrderValidateToDto(req);
+    OrderValidateDto dto = orderMapper.addOrderValidateToDto(req);
     orderCacheCreator.saveOrderTransactionId(req.getOrderTransactionId(), dto);
   }
 
   @Override
   public Set<ValidateResult> getOrderValidationStatus(String orderTransactionId) {
-    Set<GetOrderValidateResponse> response = orderCacheReader.findByOrderTransactionId(
+    Set<OrderValidateDto> response = orderCacheReader.findByOrderTransactionId(
         orderTransactionId
     );
     return orderMapper.getOrderValidateToDomain(response);

--- a/src/main/java/com/baedal/order/adapter/out/persistence/adapters/OrderCacheRepositoryAdapter.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/adapters/OrderCacheRepositoryAdapter.java
@@ -1,8 +1,10 @@
 package com.baedal.order.adapter.out.persistence.adapters;
 
 import com.baedal.order.adapter.out.persistence.manager.OrderCacheCreator;
+import com.baedal.order.adapter.out.persistence.manager.OrderCacheReader;
 import com.baedal.order.application.port.out.OrderCacheRepositoryPort;
-import java.util.UUID;
+import com.baedal.order.domain.model.SuccessOrderValidate;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,10 +13,16 @@ import org.springframework.stereotype.Component;
 public class OrderCacheRepositoryAdapter implements OrderCacheRepositoryPort {
 
   private final OrderCacheCreator orderCacheCreator;
+  private final OrderCacheReader orderCacheReader;
+
   @Override
-  public String generateAndSaveOrderTransactionId() {
-    String orderTransactionId = UUID.randomUUID().toString();
-    orderCacheCreator.saveOrderTransactionId(orderTransactionId);
-    return orderTransactionId;
+  public void successOrderValidate(SuccessOrderValidate req) {
+    orderCacheCreator.saveOrderTransactionId(req.getOrderTransactionId(), req.getDomain());
   }
+
+  @Override
+  public Set<String> getOrderValidationStatus(String orderTransactionId) {
+    return orderCacheReader.findByOrderTransactionId(orderTransactionId);
+  }
+
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/adapters/OrderCacheRepositoryAdapter.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/adapters/OrderCacheRepositoryAdapter.java
@@ -1,9 +1,13 @@
 package com.baedal.order.adapter.out.persistence.adapters;
 
+import com.baedal.order.adapter.out.persistence.dto.AddOrderValidateRequest;
+import com.baedal.order.adapter.out.persistence.dto.GetOrderValidateResponse;
 import com.baedal.order.adapter.out.persistence.manager.OrderCacheCreator;
 import com.baedal.order.adapter.out.persistence.manager.OrderCacheReader;
+import com.baedal.order.adapter.out.persistence.mapper.OrderPersistenceMapper;
 import com.baedal.order.application.port.out.OrderCacheRepositoryPort;
-import com.baedal.order.domain.model.SuccessOrderValidate;
+import com.baedal.order.domain.model.AddOrderValidate;
+import com.baedal.order.domain.model.ValidateResult;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -14,15 +18,20 @@ public class OrderCacheRepositoryAdapter implements OrderCacheRepositoryPort {
 
   private final OrderCacheCreator orderCacheCreator;
   private final OrderCacheReader orderCacheReader;
+  private final OrderPersistenceMapper orderMapper;
 
   @Override
-  public void successOrderValidate(SuccessOrderValidate req) {
-    orderCacheCreator.saveOrderTransactionId(req.getOrderTransactionId(), req.getDomain());
+  public void addOrderValidate(AddOrderValidate req) {
+    AddOrderValidateRequest dto = orderMapper.addOrderValidateToDto(req);
+    orderCacheCreator.saveOrderTransactionId(req.getOrderTransactionId(), dto);
   }
 
   @Override
-  public Set<String> getOrderValidationStatus(String orderTransactionId) {
-    return orderCacheReader.findByOrderTransactionId(orderTransactionId);
+  public Set<ValidateResult> getOrderValidationStatus(String orderTransactionId) {
+    Set<GetOrderValidateResponse> response = orderCacheReader.findByOrderTransactionId(
+        orderTransactionId
+    );
+    return orderMapper.getOrderValidateToDomain(response);
   }
 
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/dto/AddOrderValidateRequest.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/dto/AddOrderValidateRequest.java
@@ -1,11 +1,11 @@
-package com.baedal.order.adapter.in.message.dto;
+package com.baedal.order.adapter.out.persistence.dto;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class OrderValidateRequest {
+public class AddOrderValidateRequest {
 
   private String domain;
   private boolean status;

--- a/src/main/java/com/baedal/order/adapter/out/persistence/dto/GetOrderValidateResponse.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/dto/GetOrderValidateResponse.java
@@ -1,11 +1,11 @@
-package com.baedal.order.adapter.in.message.dto;
+package com.baedal.order.adapter.out.persistence.dto;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class OrderValidateRequest {
+public class GetOrderValidateResponse {
 
   private String domain;
   private boolean status;

--- a/src/main/java/com/baedal/order/adapter/out/persistence/dto/OrderValidateDto.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/dto/OrderValidateDto.java
@@ -1,11 +1,15 @@
 package com.baedal.order.adapter.out.persistence.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
-public class AddOrderValidateRequest {
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderValidateDto {
 
   private String domain;
   private boolean status;

--- a/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheCreator.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheCreator.java
@@ -1,5 +1,6 @@
 package com.baedal.order.adapter.out.persistence.manager;
 
+import com.baedal.order.adapter.out.persistence.dto.AddOrderValidateRequest;
 import com.baedal.order.adapter.out.persistence.repository.OrderRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -10,7 +11,7 @@ public class OrderCacheCreator {
 
   private final OrderRedisRepository orderRedisRepository;
 
-  public void saveOrderTransactionId(String orderTransactionId, String domain) {
-    orderRedisRepository.save("order:" + orderTransactionId, domain);
+  public void saveOrderTransactionId(String orderTransactionId, AddOrderValidateRequest dto) {
+    orderRedisRepository.save("order:" + orderTransactionId, dto);
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheCreator.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheCreator.java
@@ -1,6 +1,6 @@
 package com.baedal.order.adapter.out.persistence.manager;
 
-import com.baedal.order.adapter.out.persistence.dto.AddOrderValidateRequest;
+import com.baedal.order.adapter.out.persistence.dto.OrderValidateDto;
 import com.baedal.order.adapter.out.persistence.repository.OrderRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,7 +11,7 @@ public class OrderCacheCreator {
 
   private final OrderRedisRepository orderRedisRepository;
 
-  public void saveOrderTransactionId(String orderTransactionId, AddOrderValidateRequest dto) {
-    orderRedisRepository.save("order:" + orderTransactionId, dto);
+  public void saveOrderTransactionId(String orderTransactionId, OrderValidateDto dto) {
+    orderRedisRepository.save(orderTransactionId, dto);
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheReader.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheReader.java
@@ -1,6 +1,6 @@
 package com.baedal.order.adapter.out.persistence.manager;
 
-import com.baedal.order.adapter.out.persistence.dto.GetOrderValidateResponse;
+import com.baedal.order.adapter.out.persistence.dto.OrderValidateDto;
 import com.baedal.order.adapter.out.persistence.repository.OrderRedisRepository;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -13,9 +13,10 @@ public class OrderCacheReader {
 
   private final OrderRedisRepository orderRedisRepository;
 
-  public Set<GetOrderValidateResponse> findByOrderTransactionId(String orderTransactionId) {
-    return orderRedisRepository.getKeys(orderTransactionId).stream()
-        .map(obj -> (GetOrderValidateResponse) obj)
+  public Set<OrderValidateDto> findByOrderTransactionId(String orderTransactionId) {
+    Set<Object> set = orderRedisRepository.getKeys(orderTransactionId);
+    return set.stream()
+        .map(obj -> (OrderValidateDto) obj)
         .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheReader.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheReader.java
@@ -1,7 +1,9 @@
 package com.baedal.order.adapter.out.persistence.manager;
 
+import com.baedal.order.adapter.out.persistence.dto.GetOrderValidateResponse;
 import com.baedal.order.adapter.out.persistence.repository.OrderRedisRepository;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +13,9 @@ public class OrderCacheReader {
 
   private final OrderRedisRepository orderRedisRepository;
 
-  public Set<String> findByOrderTransactionId(String orderTransactionId) {
-    return orderRedisRepository.getKeys(orderTransactionId);
+  public Set<GetOrderValidateResponse> findByOrderTransactionId(String orderTransactionId) {
+    return orderRedisRepository.getKeys(orderTransactionId).stream()
+        .map(obj -> (GetOrderValidateResponse) obj)
+        .collect(Collectors.toSet());
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheReader.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/manager/OrderCacheReader.java
@@ -1,16 +1,17 @@
 package com.baedal.order.adapter.out.persistence.manager;
 
 import com.baedal.order.adapter.out.persistence.repository.OrderRedisRepository;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class OrderCacheCreator {
+public class OrderCacheReader {
 
   private final OrderRedisRepository orderRedisRepository;
 
-  public void saveOrderTransactionId(String orderTransactionId, String domain) {
-    orderRedisRepository.save("order:" + orderTransactionId, domain);
+  public Set<String> findByOrderTransactionId(String orderTransactionId) {
+    return orderRedisRepository.getKeys(orderTransactionId);
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/mapper/OrderPersistenceMapper.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/mapper/OrderPersistenceMapper.java
@@ -1,7 +1,6 @@
 package com.baedal.order.adapter.out.persistence.mapper;
 
-import com.baedal.order.adapter.out.persistence.dto.AddOrderValidateRequest;
-import com.baedal.order.adapter.out.persistence.dto.GetOrderValidateResponse;
+import com.baedal.order.adapter.out.persistence.dto.OrderValidateDto;
 import com.baedal.order.adapter.out.persistence.entity.OrderEntity;
 import com.baedal.order.adapter.out.persistence.entity.ProductEntity;
 import com.baedal.order.domain.model.AddOrder;
@@ -27,8 +26,8 @@ public interface OrderPersistenceMapper {
   Order toDomain(OrderEntity entity);
 
   // 검증 추가
-  AddOrderValidateRequest addOrderValidateToDto(AddOrderValidate req);
+  OrderValidateDto addOrderValidateToDto(AddOrderValidate req);
 
   // 검증 조회
-  Set<ValidateResult> getOrderValidateToDomain(Set<GetOrderValidateResponse> res);
+  Set<ValidateResult> getOrderValidateToDomain(Set<OrderValidateDto> res);
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/mapper/OrderPersistenceMapper.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/mapper/OrderPersistenceMapper.java
@@ -1,10 +1,15 @@
 package com.baedal.order.adapter.out.persistence.mapper;
 
+import com.baedal.order.adapter.out.persistence.dto.AddOrderValidateRequest;
+import com.baedal.order.adapter.out.persistence.dto.GetOrderValidateResponse;
 import com.baedal.order.adapter.out.persistence.entity.OrderEntity;
 import com.baedal.order.adapter.out.persistence.entity.ProductEntity;
 import com.baedal.order.domain.model.AddOrder;
 import com.baedal.order.domain.model.AddOrderProduct;
+import com.baedal.order.domain.model.AddOrderValidate;
 import com.baedal.order.domain.model.Order;
+import com.baedal.order.domain.model.ValidateResult;
+import java.util.Set;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -21,4 +26,9 @@ public interface OrderPersistenceMapper {
   @Mapping(target = "productInfo", source = "products")
   Order toDomain(OrderEntity entity);
 
+  // 검증 추가
+  AddOrderValidateRequest addOrderValidateToDto(AddOrderValidate req);
+
+  // 검증 조회
+  Set<ValidateResult> getOrderValidateToDomain(Set<GetOrderValidateResponse> res);
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/repository/OrderRedisRepository.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/repository/OrderRedisRepository.java
@@ -1,16 +1,21 @@
 package com.baedal.order.adapter.out.persistence.repository;
 
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class OrderRedisRepository {
 
-  private final HashOperations<String, String, String> hashOps;
+  private final RedisTemplate<String, String> redisTemplate;
 
-  public void save(String key, String field, String value) {
-    hashOps.put(key, field, value);
+  public void save(String key, String value) {
+    redisTemplate.opsForSet().add(key, value);
+  }
+
+  public Set<String> getKeys(String key) {
+    return redisTemplate.opsForSet().members(key);
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/repository/OrderRedisRepository.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/repository/OrderRedisRepository.java
@@ -11,11 +11,17 @@ public class OrderRedisRepository {
 
   private final RedisTemplate<String, Object> redisTemplate;
 
+  private String ORDER_PREFIX = "order:";
+
+  private String getKey(String key) {
+    return ORDER_PREFIX + key;
+  }
+
   public void save(String key, Object value) {
-    redisTemplate.opsForSet().add(key, value);
+    redisTemplate.opsForSet().add(getKey(key), value);
   }
 
   public Set<Object> getKeys(String key) {
-    return redisTemplate.opsForSet().members(key);
+    return redisTemplate.opsForSet().members(getKey(key));
   }
 }

--- a/src/main/java/com/baedal/order/adapter/out/persistence/repository/OrderRedisRepository.java
+++ b/src/main/java/com/baedal/order/adapter/out/persistence/repository/OrderRedisRepository.java
@@ -9,13 +9,13 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class OrderRedisRepository {
 
-  private final RedisTemplate<String, String> redisTemplate;
+  private final RedisTemplate<String, Object> redisTemplate;
 
-  public void save(String key, String value) {
+  public void save(String key, Object value) {
     redisTemplate.opsForSet().add(key, value);
   }
 
-  public Set<String> getKeys(String key) {
+  public Set<Object> getKeys(String key) {
     return redisTemplate.opsForSet().members(key);
   }
 }

--- a/src/main/java/com/baedal/order/application/command/OrderValidateCommand.java
+++ b/src/main/java/com/baedal/order/application/command/OrderValidateCommand.java
@@ -7,9 +7,11 @@ public class OrderValidateCommand {
 
   @Getter
   @Builder
-  public static class Request{
+  public static class Request {
     private String orderTransactionId;
     private String domain;
+    private boolean status;
+    private String message;
   }
 
 }

--- a/src/main/java/com/baedal/order/application/command/OrderValidateCommand.java
+++ b/src/main/java/com/baedal/order/application/command/OrderValidateCommand.java
@@ -1,0 +1,15 @@
+package com.baedal.order.application.command;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class OrderValidateCommand {
+
+  @Getter
+  @Builder
+  public static class Request{
+    private String orderTransactionId;
+    private String domain;
+  }
+
+}

--- a/src/main/java/com/baedal/order/application/mapper/OrderApplicationMapper.java
+++ b/src/main/java/com/baedal/order/application/mapper/OrderApplicationMapper.java
@@ -2,7 +2,8 @@ package com.baedal.order.application.mapper;
 
 import com.baedal.order.application.command.AddOrderCommand;
 import com.baedal.order.application.command.OrderValidateCommand;
-import com.baedal.order.domain.model.SuccessOrderValidate;
+import com.baedal.order.domain.model.AddOrderValidate;
+import com.baedal.order.domain.model.ValidateResult;
 import com.baedal.order.domain.model.cart.ValidateCartOrderInfo;
 import com.baedal.order.domain.model.product.ValidateProductOrderInfo;
 import com.baedal.order.domain.model.store.ValidateStoreOrderInfo;
@@ -39,5 +40,6 @@ public interface OrderApplicationMapper {
   AddOrderCommand.Response getPaymentUrlToResponse(GetPaymentUrl.Response res);
 
   // 주문 검증
-  SuccessOrderValidate orderValidateToDomain(OrderValidateCommand.Request req);
+  ValidateResult orderValidateResultToDomain(OrderValidateCommand.Request req);
+  AddOrderValidate addOrderValidateToDomain(OrderValidateCommand.Request req);
 }

--- a/src/main/java/com/baedal/order/application/mapper/OrderApplicationMapper.java
+++ b/src/main/java/com/baedal/order/application/mapper/OrderApplicationMapper.java
@@ -1,6 +1,8 @@
 package com.baedal.order.application.mapper;
 
 import com.baedal.order.application.command.AddOrderCommand;
+import com.baedal.order.application.command.OrderValidateCommand;
+import com.baedal.order.domain.model.SuccessOrderValidate;
 import com.baedal.order.domain.model.cart.ValidateCartOrderInfo;
 import com.baedal.order.domain.model.product.ValidateProductOrderInfo;
 import com.baedal.order.domain.model.store.ValidateStoreOrderInfo;
@@ -35,4 +37,7 @@ public interface OrderApplicationMapper {
   );
 
   AddOrderCommand.Response getPaymentUrlToResponse(GetPaymentUrl.Response res);
+
+  // 주문 검증
+  SuccessOrderValidate orderValidateToDomain(OrderValidateCommand.Request req);
 }

--- a/src/main/java/com/baedal/order/application/port/in/OrderUseCase.java
+++ b/src/main/java/com/baedal/order/application/port/in/OrderUseCase.java
@@ -1,9 +1,13 @@
 package com.baedal.order.application.port.in;
 
 import com.baedal.order.application.command.AddOrderCommand;
+import com.baedal.order.application.command.OrderValidateCommand;
 
 public interface OrderUseCase {
 
   // 주문 등록
   AddOrderCommand.Response addOrder(AddOrderCommand.Request req);
+
+  // 주문 검증
+  void orderValidate(OrderValidateCommand.Request req);
 }

--- a/src/main/java/com/baedal/order/application/port/out/MessageSenderPort.java
+++ b/src/main/java/com/baedal/order/application/port/out/MessageSenderPort.java
@@ -11,4 +11,6 @@ public interface MessageSenderPort {
   void validateProductOrderInfo(ValidateProductOrderInfo.Request req);
 
   void validateStoreOrderInfo(ValidateStoreOrderInfo.Request req);
+
+  void approvePayment(String orderTransactionId);
 }

--- a/src/main/java/com/baedal/order/application/port/out/MessageSenderPort.java
+++ b/src/main/java/com/baedal/order/application/port/out/MessageSenderPort.java
@@ -13,4 +13,6 @@ public interface MessageSenderPort {
   void validateStoreOrderInfo(ValidateStoreOrderInfo.Request req);
 
   void approvePayment(String orderTransactionId);
+
+  void failOrder(String orderTransactionId, String errorMessage);
 }

--- a/src/main/java/com/baedal/order/application/port/out/OrderCacheRepositoryPort.java
+++ b/src/main/java/com/baedal/order/application/port/out/OrderCacheRepositoryPort.java
@@ -1,11 +1,12 @@
 package com.baedal.order.application.port.out;
 
-import com.baedal.order.domain.model.SuccessOrderValidate;
+import com.baedal.order.domain.model.AddOrderValidate;
+import com.baedal.order.domain.model.ValidateResult;
 import java.util.Set;
 
 public interface OrderCacheRepositoryPort {
 
-  void successOrderValidate(SuccessOrderValidate req);
+  void addOrderValidate(AddOrderValidate req);
 
-  Set<String> getOrderValidationStatus(String orderTransactionId);
+  Set<ValidateResult> getOrderValidationStatus(String orderTransactionId);
 }

--- a/src/main/java/com/baedal/order/application/port/out/OrderCacheRepositoryPort.java
+++ b/src/main/java/com/baedal/order/application/port/out/OrderCacheRepositoryPort.java
@@ -1,7 +1,11 @@
 package com.baedal.order.application.port.out;
 
+import com.baedal.order.domain.model.SuccessOrderValidate;
+import java.util.Set;
+
 public interface OrderCacheRepositoryPort {
 
-  String generateAndSaveOrderTransactionId();
+  void successOrderValidate(SuccessOrderValidate req);
 
+  Set<String> getOrderValidationStatus(String orderTransactionId);
 }

--- a/src/main/java/com/baedal/order/application/service/OrderService.java
+++ b/src/main/java/com/baedal/order/application/service/OrderService.java
@@ -1,7 +1,7 @@
 package com.baedal.order.application.service;
 
 import com.baedal.order.application.command.AddOrderCommand;
-import com.baedal.order.application.command.OrderValidateCommand;
+import com.baedal.order.application.command.OrderValidateCommand.Request;
 import com.baedal.order.application.mapper.OrderApplicationMapper;
 import com.baedal.order.application.port.in.OrderUseCase;
 import com.baedal.order.application.port.out.MessageSenderPort;
@@ -9,7 +9,8 @@ import com.baedal.order.application.port.out.OrderCacheRepositoryPort;
 import com.baedal.order.application.port.out.PaymentClientPort;
 import com.baedal.order.domain.business.FutureManager;
 import com.baedal.order.domain.business.OrderValidate;
-import com.baedal.order.domain.model.SuccessOrderValidate;
+import com.baedal.order.domain.model.AddOrderValidate;
+import com.baedal.order.domain.model.ValidateResult;
 import com.baedal.order.domain.model.cart.ValidateCartOrderInfo;
 import com.baedal.order.domain.model.payment.GetPaymentUrl.Response;
 import com.baedal.order.domain.model.product.ValidateProductOrderInfo;
@@ -78,22 +79,33 @@ public class OrderService implements OrderUseCase {
   }
 
   @Override
-  public void orderValidate(OrderValidateCommand.Request req) {
+  public void orderValidate(Request req) {
 
-    String domain = req.getDomain();
     String orderTransactionId = req.getOrderTransactionId();
 
     // 검증 결과 조회
-    Set<String> domains = orderCacheRepository.getOrderValidationStatus(orderTransactionId);
+    Set<ValidateResult> result = orderCacheRepository.getOrderValidationStatus(orderTransactionId);
 
-    // 모든 검증에 성공했을 경우 결제 승인 메세지 큐를 던짐
-    if (orderValidate.validate(domains, domain)) {
-      messageSenderPort.approvePayment(orderTransactionId);
+    // 전달 받은 요청을 검증 결과에 포함
+    ValidateResult tempResult = mapper.orderValidateResultToDomain(req);
+    result.add(tempResult);
+
+    // 크기가 기준에 미치지 못할 경우 검증 결과를 저장하고 종료
+    if (!orderValidate.validateCount(result)) {
+      AddOrderValidate addOrderValidateReq = mapper.addOrderValidateToDomain(req);
+      orderCacheRepository.addOrderValidate(addOrderValidateReq);
       return;
     }
 
-    // 검증 진행 중인 경우 검증 결과를 저장함
-    SuccessOrderValidate request = mapper.orderValidateToDomain(req);
-    orderCacheRepository.successOrderValidate(request);
+    // 실패한 검증이 있으면 주문 실패 메세지 전달하고 종료
+    String errorMessage = orderValidate.getErrorMessage(result);
+    if (errorMessage != null) {
+      messageSenderPort.failOrder(orderTransactionId, errorMessage);
+      return;
+    }
+
+    // 검증 성공시 결제 승인 메세지 전달
+    messageSenderPort.approvePayment(orderTransactionId);
+
   }
 }

--- a/src/main/java/com/baedal/order/application/service/OrderService.java
+++ b/src/main/java/com/baedal/order/application/service/OrderService.java
@@ -97,15 +97,15 @@ public class OrderService implements OrderUseCase {
       return;
     }
 
-    // 실패한 검증이 있으면 주문 실패 메세지 전달하고 종료
-    String errorMessage = orderValidate.getErrorMessage(result);
-    if (errorMessage != null) {
-      messageSenderPort.failOrder(orderTransactionId, errorMessage);
-      return;
-    }
+    orderValidate.getErrorMessage(result).ifPresentOrElse(message -> {
+      // 실패한 검증이 있으면 주문 실패 메세지 전달하고 종료
+      messageSenderPort.failOrder(orderTransactionId, message);
 
-    // 검증 성공시 결제 승인 메세지 전달
-    messageSenderPort.approvePayment(orderTransactionId);
+    }, () -> {
+      // 검증 성공시 결제 승인 메세지 전달
+      messageSenderPort.approvePayment(orderTransactionId);
+    });
+
 
   }
 }

--- a/src/main/java/com/baedal/order/application/service/OrderService.java
+++ b/src/main/java/com/baedal/order/application/service/OrderService.java
@@ -1,17 +1,22 @@
 package com.baedal.order.application.service;
 
 import com.baedal.order.application.command.AddOrderCommand;
+import com.baedal.order.application.command.OrderValidateCommand;
 import com.baedal.order.application.mapper.OrderApplicationMapper;
 import com.baedal.order.application.port.in.OrderUseCase;
 import com.baedal.order.application.port.out.MessageSenderPort;
 import com.baedal.order.application.port.out.OrderCacheRepositoryPort;
 import com.baedal.order.application.port.out.PaymentClientPort;
 import com.baedal.order.domain.business.FutureManager;
+import com.baedal.order.domain.business.OrderValidate;
+import com.baedal.order.domain.model.SuccessOrderValidate;
 import com.baedal.order.domain.model.cart.ValidateCartOrderInfo;
 import com.baedal.order.domain.model.payment.GetPaymentUrl.Response;
 import com.baedal.order.domain.model.product.ValidateProductOrderInfo;
 import com.baedal.order.domain.model.store.ValidateStoreOrderInfo;
 import com.baedal.order.domain.model.payment.GetPaymentUrl;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -30,6 +35,7 @@ public class OrderService implements OrderUseCase {
   private final OrderCacheRepositoryPort orderCacheRepository;
   private final MessageSenderPort messageSenderPort;
   private final PaymentClientPort paymentClientPort;
+  private final OrderValidate orderValidate;
 
   /**
    * 응답 값을 받아오는 요청에만 버츄얼 스레드 적용
@@ -42,8 +48,8 @@ public class OrderService implements OrderUseCase {
     // 회원ID
     String userId = "1";
 
-    // 상태 추적을 위한 고유값(UUID) 생성 및 캐시 저장
-    String orderTransactionId = orderCacheRepository.generateAndSaveOrderTransactionId();
+    // 상태 추적을 위한 고유값(UUID) 생성
+    String orderTransactionId = UUID.randomUUID().toString();
 
     // 결제 요청 전송 및 결제 URL 반환
     Future<Response> paymentFuture = executorService.submit(() -> {
@@ -69,5 +75,25 @@ public class OrderService implements OrderUseCase {
 
     GetPaymentUrl.Response paymentResponse = futureManager.extract(paymentFuture);
     return mapper.getPaymentUrlToResponse(paymentResponse);
+  }
+
+  @Override
+  public void orderValidate(OrderValidateCommand.Request req) {
+
+    String domain = req.getDomain();
+    String orderTransactionId = req.getOrderTransactionId();
+
+    // 검증 결과 조회
+    Set<String> domains = orderCacheRepository.getOrderValidationStatus(orderTransactionId);
+
+    // 모든 검증에 성공했을 경우 결제 승인 메세지 큐를 던짐
+    if (orderValidate.validate(domains, domain)) {
+      messageSenderPort.approvePayment(orderTransactionId);
+      return;
+    }
+
+    // 검증 진행 중인 경우 검증 결과를 저장함
+    SuccessOrderValidate request = mapper.orderValidateToDomain(req);
+    orderCacheRepository.successOrderValidate(request);
   }
 }

--- a/src/main/java/com/baedal/order/config/KafkaConsumerConfig.java
+++ b/src/main/java/com/baedal/order/config/KafkaConsumerConfig.java
@@ -1,0 +1,37 @@
+package com.baedal.order.config;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+public class KafkaConsumerConfig {
+
+  @Value("${spring.kafka.producer.bootstrap-servers}")
+  private String bootstrapServers;
+
+  @Bean
+  public ConsumerFactory<String, Object> consumerFactory() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+    return new DefaultKafkaConsumerFactory<>(properties);
+  }
+
+  @Bean
+  public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(consumerFactory());
+    return factory;
+  }
+}

--- a/src/main/java/com/baedal/order/config/KafkaProducerConfig.java
+++ b/src/main/java/com/baedal/order/config/KafkaProducerConfig.java
@@ -13,7 +13,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
-public class KafkaConfig {
+public class KafkaProducerConfig {
 
   @Value("${spring.kafka.producer.bootstrap-servers}")
   private String bootstrapServers;
@@ -37,3 +37,4 @@ public class KafkaConfig {
     return configProps;
   }
 }
+

--- a/src/main/java/com/baedal/order/config/RedisConfig.java
+++ b/src/main/java/com/baedal/order/config/RedisConfig.java
@@ -2,16 +2,24 @@ package com.baedal.order.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
 
   @Bean
-  public HashOperations<String, String, String> hashOperations(
-      RedisTemplate<String, String> redisTemplate) {
-    return redisTemplate.opsForHash();
-  };
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory){
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory);
+    redisTemplate.setDefaultSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+    redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+    return redisTemplate;
+  }
+
 
 }

--- a/src/main/java/com/baedal/order/domain/business/OrderValidate.java
+++ b/src/main/java/com/baedal/order/domain/business/OrderValidate.java
@@ -1,0 +1,16 @@
+package com.baedal.order.domain.business;
+
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderValidate {
+
+  // 검증 해야 하는 도메인 갯수
+  private final int COUNT = 4;
+
+  public boolean validate(Set<String> domains, String domain) {
+    domains.add(domain);
+    return domains.size() >= COUNT;
+  }
+}

--- a/src/main/java/com/baedal/order/domain/business/OrderValidate.java
+++ b/src/main/java/com/baedal/order/domain/business/OrderValidate.java
@@ -1,5 +1,6 @@
 package com.baedal.order.domain.business;
 
+import com.baedal.order.domain.model.ValidateResult;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -9,8 +10,18 @@ public class OrderValidate {
   // 검증 해야 하는 도메인 갯수
   private final int COUNT = 4;
 
-  public boolean validate(Set<String> domains, String domain) {
-    domains.add(domain);
+
+  public boolean validateCount(Set<ValidateResult> domains) {
     return domains.size() >= COUNT;
   }
+
+  public String getErrorMessage(Set<ValidateResult> results) {
+    return results.stream()
+        .filter(result -> !result.isStatus())
+        .map(ValidateResult::getMessage)
+        .findFirst()
+        .orElse(null);
+  }
+
+
 }

--- a/src/main/java/com/baedal/order/domain/business/OrderValidate.java
+++ b/src/main/java/com/baedal/order/domain/business/OrderValidate.java
@@ -1,6 +1,7 @@
 package com.baedal.order.domain.business;
 
 import com.baedal.order.domain.model.ValidateResult;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -15,12 +16,11 @@ public class OrderValidate {
     return domains.size() >= COUNT;
   }
 
-  public String getErrorMessage(Set<ValidateResult> results) {
+  public Optional<String> getErrorMessage(Set<ValidateResult> results) {
     return results.stream()
         .filter(result -> !result.isStatus())
         .map(ValidateResult::getMessage)
-        .findFirst()
-        .orElse(null);
+        .findFirst();
   }
 
 

--- a/src/main/java/com/baedal/order/domain/model/AddOrderValidate.java
+++ b/src/main/java/com/baedal/order/domain/model/AddOrderValidate.java
@@ -1,12 +1,13 @@
-package com.baedal.order.adapter.in.message.dto;
+package com.baedal.order.domain.model;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class OrderValidateRequest {
+public class AddOrderValidate {
 
+  private String orderTransactionId;
   private String domain;
   private boolean status;
   private String message;

--- a/src/main/java/com/baedal/order/domain/model/AddOrderValidate.java
+++ b/src/main/java/com/baedal/order/domain/model/AddOrderValidate.java
@@ -1,10 +1,14 @@
 package com.baedal.order.domain.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class AddOrderValidate {
 
   private String orderTransactionId;

--- a/src/main/java/com/baedal/order/domain/model/SuccessOrderValidate.java
+++ b/src/main/java/com/baedal/order/domain/model/SuccessOrderValidate.java
@@ -1,0 +1,13 @@
+package com.baedal.order.domain.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SuccessOrderValidate {
+
+  private String orderTransactionId;
+  private String domain;
+
+}

--- a/src/main/java/com/baedal/order/domain/model/ValidateResult.java
+++ b/src/main/java/com/baedal/order/domain/model/ValidateResult.java
@@ -1,11 +1,11 @@
-package com.baedal.order.adapter.in.message.dto;
+package com.baedal.order.domain.model;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class OrderValidateRequest {
+public class ValidateResult {
 
   private String domain;
   private boolean status;

--- a/src/main/java/com/baedal/order/util/Converter.java
+++ b/src/main/java/com/baedal/order/util/Converter.java
@@ -1,0 +1,20 @@
+package com.baedal.order.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class Converter {
+
+  private final ObjectMapper objectMapper;
+
+  public <T> T jsonToDto(String value, Class<T> dtoClass) {
+    try {
+      return objectMapper.readValue(value, dtoClass);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
주문 검증 구현하였습니다.
[ 검증 성공 -> 주문 검증 ] 으로 변경된 사항이며 참고 부탁드립니다. 

작업 목표는 아래와 같았습니다.

1. 모든 검증이 완료된 이후에 결제 승인 메세지 큐를 전달
2. 결제가 성공하고, 다른 검증은 실패할 경우 주문 실패 메세지 큐를 전달


위와 같은 목표를 위해 [주문 검증] 이라는 리스너를 만들게 되었고 모든 검증을 해당 리스너에서 처리하려 하였습니다.
다만, 주문 요청의 SAGA 패턴으로 인해 아래와 같은 사항을 고려해야만 했습니다.

1. 도메인의 검증은 완료가 되었으나, 결제 요청이 전달되지 않는 케이스
2. 결제 요청은 완료 되었으나, 도메인의 검증이 전달되지 않는 케이스
3. 검증 과정 중 데이터가 유실 되거나 상당 시간 지연되는 케이스


위와 같은 조건들로 인해 검증 단계에서 아래와 같은 기능을 구현해야 했습니다.

1. 모든 도메인의 검증 여부 확인
2. 검증 성공 유무 확인 (true/false)
3. 결제 성공 유무에 따른 메세지 큐 전송


여기서 위에 나열한 케이스와 조건들을 충족 시키기 위해서는 하나의 서비스에서 과도한 책임/역할을 부여하게 되는 것같아 기존에는 검증 성공/실패 리스너를 분리하는 방향으로 고민을 하였습니다.
하지만 현재 구조에서 리스너를 분리해도 공통적으로 활용해야 하는 로직과 저장소로 인해 이후 유지보수의 어려움이 예상 되었고,
분리하게 됨으로 얻을 수 있는 속도적인 이점도 존재하지 않았기에 주문 검증 이라는 하나의 리스너에는 검증이라는 최소한의 역할만을 부여하여 속도적인 이점을 얻을 수 있도록 하였습니다.

기본적인 흐름은 아래와 같습니다.

1. 현재까지의 검증 결과를 조회
1-1. 검증 갯수가 부족하다면 검증 결과를 저장하고 종료
2. 검증 갯수가 충족되었지만, 실패한 검증이 있다면 주문 실패 토픽으로 메세지를 전달하고 종료
3. 검증 성공시 결제 승인 토픽으로 메세지를 전달하고 종료


전달 되는 대부분의 요청이 1-1 에서 종료되어 최소한의 자원을 소비하도록 하였고 이후의 과정은 메세지를 활용하여 빠른 속도를 보장하였습니다.
이러한 구조는 대부분의 요청을 처리할 수 있을 것으로 예상이 되나, SAGA 패턴으로 인한 3번 케이스에 대한 조치가 불가능 하였습니다.
하지만 3번 케이스의 경우는 비교적 발생할 가능성이 낮은 상황이기도 하였으며, 이를 위해 추가적인 로직을 작성하는 것은 비효율적이라 판단하여 이는 지연 큐를 활용하여 다른 리스너에서 해결하기로 하였습니다.



++

1. 모든 도메인의 검증이 완료 되었는지 구분만 하는 로직
2. 검증이 완료된 결과를 확인하고 성공 여부를 구분하는 로직

위와 같은 방식으로 책임/역할을 구분하는 방안도 고민하였습니다.
다만, 현재는 많은 처리 과정이 존재하지 않았고 테스트 결과 0.164ms 정도의 미미한 차이 밖에 확인되지 않았습니다. 기존(분리 전) 로직에 비교적 유리한 방식으로 테스트를 진행했었기에, 실제 운영 환경에서는 유의미한 성능적인 이점을 확인할 수 없을 것같아 채택하지 않았습니다.


테스트 조건은 아래와 같습니다
1. 1000번의 요청을 순차적으로 처리
2. 하나의 ID 는 무조건 4번의 요청을 보냄 (필수적으로 검증 성공 여부 확인 과정을 거쳐야함)

결과

분리전 -> 8.261ms
분리후 -> 8.097ms

